### PR TITLE
Added config option to place source file to the left/right of the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "cpp-group" extension will be documented in this file
 ### Added 
 
 - Added support for `.c` files
+- Added option `cpp-group.isSourceLeft` to configure if the source file must be placed to the left of the header file. True by default.
 
 ## [1.0.0] - 2024-05-20
 Initial Release

--- a/package.json
+++ b/package.json
@@ -37,5 +37,17 @@
     "@typescript-eslint/parser": "^7.7.1",
     "eslint": "^8.57.0",
     "typescript": "^5.4.5"
+  },
+  "contributes": {
+    "configuration": {
+      "title": "cpp-group",
+      "properties": {
+        "cpp-group.isSourceLeft": {
+          "type": "boolean",
+          "default": true,
+          "description": "Place the source file to the left of the header file"
+        }
+      }
+    }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-
 	vscode.window.tabGroups.onDidChangeTabs( ( e: vscode.TabChangeEvent ) => {
 		e.opened.forEach( openedTab => {
 			if( !( openedTab.input instanceof vscode.TabInputText ) ) {
@@ -31,9 +30,17 @@ export function activate(context: vscode.ExtensionContext) {
 				} );
 
 				if( pairTab !== undefined ) {
+					let isSourceLeft : boolean = true;
+					let extensionConfigs : vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration( "cpp-group" );
+					if( extensionConfigs.has( "isSourceLeft" ) ) {
+						let readValue = extensionConfigs.get< boolean >( "isSourceLeft" );
+						if( readValue != undefined ) {
+							isSourceLeft = readValue;
+						}
+					}
 					const currTabGroup : vscode.TabGroup = openedTab.group;
 					const pairTabIdx : number = currTabGroup.tabs.indexOf( pairTab );
-					const newIdx : number = pairTabIdx + ( isSourceFile ? 1 : 2 );	// current schema places .cpp file to the left and the .h file to the right
+					const newIdx : number = pairTabIdx + ( isSourceFile == isSourceLeft ? 1 : 2 ); // XOR operation
 					vscode.commands.executeCommand('moveActiveEditor', { to: 'position', by: 'tab', value: newIdx } );
 				}
 			}


### PR DESCRIPTION
## Brief
Adds configuration option (`cpp-group.isSourceLeft)` to let users configure if they want to place the source file to the left/right of a matching header file.

## Issues addressed
Closes #3 